### PR TITLE
Fix error when user doesn't have domain_access field

### DIFF
--- a/domain_access/src/DomainAccessManager.php
+++ b/domain_access/src/DomainAccessManager.php
@@ -52,7 +52,7 @@ class DomainAccessManager implements DomainAccessManagerInterface {
       return $list;
     }
     // Get the values of an entity.
-    $values = $entity->get($field_name);
+    $values = $entity->hasField($field_name) ? $entity->get($field_name) : NULL;
     // Must be at least one item.
     if (!empty($values)) {
       foreach ($values as $item) {


### PR DESCRIPTION
Adding validation to prevent InvalidArgumentException when $entity doesn't have the field_domain_access field.